### PR TITLE
Update references to phaser type definitions

### DIFF
--- a/app/src/ts/renderer/index.ts
+++ b/app/src/ts/renderer/index.ts
@@ -1,11 +1,11 @@
-import 'phaser'
+import 'phaser';
 
 import { BootScene } from "@renderer/scenes/bootScene";
 import { MainMenuScene } from "@renderer/scenes/mainMenuScene";
 import { GameScene } from "@renderer/scenes/gameScene";
 import { APP_WIDTH, APP_HEIGHT } from '@shared/constants';
 
-const config: GameConfig = {
+const config: Phaser.Types.Core.GameConfig = {
   title: "Flappy Bird",
   version: "1.0",
   width: APP_WIDTH,
@@ -35,7 +35,7 @@ const config: GameConfig = {
 };
 
 export class Game extends Phaser.Game {
-  constructor(config: GameConfig) {
+  constructor(config: Phaser.Types.Core.GameConfig) {
     super(config);
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "phaser": "3.13.0"
+    "phaser": "3.19.0"
   },
   "devDependencies": {
     "awesome-typescript-loader": "5.2.1",
@@ -51,7 +51,6 @@
     "electron-builder": "20.28.4",
     "file-loader": "2.0.0",
     "html-webpack-plugin": "3.2.0",
-    "phaser3-docs": "git+ssh://git@github.com:photonstorm/phaser3-docs.git",
     "rimraf": "2.6.2",
     "source-map-loader": "0.2.4",
     "typescript": "3.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
   },
   "include": [
       "./app/src/ts/**/*",
-      "./node_modules/phaser3-docs/typescript"
+      "./node_modules/phaser/types"
   ]
 }


### PR DESCRIPTION
Phaser type definitions have been moved from the phaser3-docs repository to the photonstorm/phaser repository. I've updated the following files to correct this: 

package.json
- Update phaser to latest release (3.19.0)
- Remove 'phaser3-docs' dev dependency

tsconfig.json:
- update reference to phaser type definitions

index.ts
- update reference to GameConfig